### PR TITLE
feat: add temperature and tokens sliders

### DIFF
--- a/public/astra.css
+++ b/public/astra.css
@@ -50,6 +50,8 @@ body{
 #sidebar.open ~ #sidebar-overlay{display:block}
 .sidebar-content{padding:22px 18px;display:flex;flex-direction:column;gap:14px}
 .close-btn{font-size:28px;align-self:flex-end}
+.sidebar-content label{display:flex;justify-content:space-between;font-size:14px}
+.sidebar-content label span{color:var(--muted)}
 .sidebar-content input[type="range"]{width:100%}
 
 /* 3-COLUMN PAGE GRID */

--- a/public/astra.js
+++ b/public/astra.js
@@ -5,6 +5,8 @@ const promptInput = document.getElementById('prompt');
 const status = document.getElementById('status');
 const tempInput = document.getElementById('temperature');
 const tempValue = document.getElementById('temp-value');
+const tokensInput = document.getElementById('tokens');
+const tokensValue = document.getElementById('tokens-value');
 const thread = document.getElementById('chat-thread');
 
 // Sidebar/flyout
@@ -29,6 +31,9 @@ function closeSidebar() {
 tempInput.addEventListener('input', () => {
   tempValue.textContent = tempInput.value;
 });
+tokensInput.addEventListener('input', () => {
+  tokensValue.textContent = tokensInput.value;
+});
 
 let controller = null;
 
@@ -51,6 +56,7 @@ form.addEventListener('submit', async (e) => {
   const prompt = promptInput.value.trim();
   if (!prompt) return;
   const temperature = parseFloat(tempInput.value);
+  const maxTokens = parseInt(tokensInput.value, 10);
 
   sendBtn.disabled = true;
   stopBtn.disabled = false;
@@ -67,7 +73,7 @@ form.addEventListener('submit', async (e) => {
     const res = await fetch('https://api.arkoninteractive.com/api/chat/stream', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt, temperature }),
+      body: JSON.stringify({ prompt, temperature, max_tokens: maxTokens }),
       signal: controller.signal
     });
 

--- a/public/index.html
+++ b/public/index.html
@@ -25,8 +25,11 @@
     <div class="sidebar-content">
       <button id="close-sidebar" class="icon-btn close-btn" aria-label="Close menu">&times;</button>
       <h2>Settings</h2>
-      <label for="temperature">Temperature: <span id="temp-value">0.2</span></label>
+      <label for="temperature">Temperature <span id="temp-value">0.2</span></label>
       <input type="range" id="temperature" min="0" max="1" step="0.01" value="0.2" />
+
+      <label for="tokens">Max Tokens <span id="tokens-value">1000</span></label>
+      <input type="range" id="tokens" min="100" max="4000" step="100" value="1000" />
     </div>
   </aside>
   <div id="sidebar-overlay"></div>


### PR DESCRIPTION
## Summary
- add temperature and max token sliders to settings sidebar
- style sidebar labels for minimal layout
- wire sliders into chat request payload

## Testing
- `npm test` *(fails: Cannot find module '../src' imported from '/workspace/astra/test/index.spec.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a237b7483c8329a8ff83483501caa5